### PR TITLE
Optimize Rust Skeleton Code

### DIFF
--- a/rust/cjdns_sys/src/lib.rs
+++ b/rust/cjdns_sys/src/lib.rs
@@ -1,23 +1,29 @@
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+
 // This is needed to make sure the linker will pull in sodium here
 pub fn init_sodium() {
     sodiumoxide::init().unwrap();
 }
 
+pub fn c_args() -> Vec<*mut c_char> {
+    std::env::args()
+        .map(|arg| CString::new(arg).unwrap())
+        .map(|arg| arg.into_raw())
+        .collect::<Vec<_>>()
+}
+
 #[macro_export]
 macro_rules! c_main {
     ($cmain:ident) => {
-        use std::ffi::CString;
-        use std::os::raw::c_char;
-        use std::os::raw::c_int;
         extern "C" {
             fn $cmain(argc: c_int, argv: *const *mut c_char);
         }
-        fn main() {
+
+        pub fn main() {
             cjdns_sys::init_sodium();
-            let c_args = std::env::args()
-                .map(|arg| CString::new(arg).unwrap())
-                .map(|arg| arg.into_raw())
-                .collect::<Vec<*mut c_char>>();
+            let c_args = cjdns_sys::c_args();
             unsafe { $cmain(c_args.len() as c_int, c_args.as_ptr()) }
         }
     };


### PR DESCRIPTION
Since Rust macros are expanded before any compilation takes place, having code that actually does stuff in the macro increases compile time for group compiles. This can easily be solved by moving the code outside the macro into a function that is shared by each of the binaries.

I simply extracted the code into a function and referenced that function inside the macro.