### PR TITLE
Make the rust code a thin layer around the C main

### DIFF
--- a/rust/cjdns_sys/src/lib.rs
+++ b/rust/cjdns_sys/src/lib.rs
@@ -9,16 +9,16 @@ macro_rules! c_main {
         use std::ffi::CString;
         use std::os::raw::c_char;
         use std::os::raw::c_int;
+        
         extern "C" {
             fn $cmain(argc: c_int, argv: *const *mut c_char);
         }
-        fn main() {
+        
+        #[no_mangle]
+        pub extern "C" fn main(argc: c_int, argv: *const *mut c_char) -> c_int {
             cjdns_sys::init_sodium();
-            let c_args = std::env::args()
-                .map(|arg| CString::new(arg).unwrap())
-                .map(|arg| arg.into_raw())
-                .collect::<Vec<*mut c_char>>();
             unsafe { $cmain(c_args.len() as c_int, c_args.as_ptr()) }
+            0
         }
     };
 }


### PR DESCRIPTION
Currently, the Rust wrapper code takes command line arguments from the Rust "runtime" and converts them back into C-style strings. This takes many heap allocations (`O(n)`) because it has to take the already-processed Rust args and allocate separate `CString` structures for the strings fed into the C main functions. This commit removes this indirection, making the Rust code a thin wrapper around the C main functions (all it does is initialize the sodiumoxide library).

This change comes with two advantages:

1. Improved speed and memory usage due to less heap allocations (which were unneeded anyways).
2. This does not limit you from integrating more Rust code because you can still add rust code inside the custom main function. When there's not enough C code underneath the wrapping main function, you can easily just remove the extraneous annotations and switch back to the normal Rust runtime with minimal friction.