### PR TITLE
Convert travis config to Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-language: c
+language: rust
 branches:
   only:
     - crashey
     - master
     - allocator-fixes
 
+rust:
+  - stable
+  
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
Since the build system will be based on Rust, the CI needs to be Rust oriented as well.